### PR TITLE
Support custom url in depaginate for proxy

### DIFF
--- a/addon/models/collection.js
+++ b/addon/models/collection.js
@@ -36,7 +36,7 @@ export default Ember.ArrayProxy.extend(TypeMixin, {
     return store.request(opt);
   },
 
-  depaginate: function(depth) {
+  depaginate: function(depth, opt) {
     var self = this;
 
     depth = depth || 1;
@@ -51,7 +51,15 @@ export default Ember.ArrayProxy.extend(TypeMixin, {
     */
 
     var promise = new Ember.RSVP.Promise(function(resolve,reject) {
-      var next = self.get('pagination.next');
+      var next = self.get('pagination.next') || ''
+      if(opt && next.indexOf('?') !== -1) {
+        let queryString = next.slice(next.indexOf('?'))
+        let url = opt.url || ''
+        if (url.indexOf('?') !== -1) {
+          url = url.slice(0, url.indexOf('?'))
+        }
+        next = url + queryString
+      }
       if ( next )
       {
         console.log('Depaginate, requesting', next);

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -429,7 +429,7 @@ var Store = Ember.Service.extend({
 
       // Depaginate
       if ( opt.depaginate && typeof response.depaginate === 'function' ) {
-        return response.depaginate().then(function() {
+        return response.depaginate(null, opt).then(function() {
           return response;
         }).catch((xhr) => {
           return this._requestFailed(xhr,opt);


### PR DESCRIPTION
When used `depaginate`, the respond `pagination.next` is not supported proxy, so I think it should add an `opt.url` for `depaginate` to request the proxy URL.