### PR TITLE
Increasing serialization depth to 20

### DIFF
--- a/addon/mixins/serializable.js
+++ b/addon/mixins/serializable.js
@@ -5,7 +5,7 @@ var Serializable = Ember.Mixin.create({
     depth = depth || 0;
     var output;
 
-    if ( depth > 10 )
+    if ( depth > 20 )
     {
       return null;
     }
@@ -28,7 +28,7 @@ var Serializable = Ember.Mixin.create({
 
     function recurse(obj,depth) {
       depth = depth || 0;
-      if ( depth > 10 )
+      if ( depth > 20 )
       {
         return null;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/ember-api-store",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
To accomdate larger nesting depths I'm increasing the serialization
depth to 20.

20 is chosen arbitrarily, it's simply double the previous depth. The
we maintain a maximum depth is to break circular dependencies.

rancher/rancher#23210