### PR TITLE
Don't validate if the a field nullable and null

### DIFF
--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -134,10 +134,7 @@ var Resource = Actionable.extend(TypeMixin, {
       }
 
       if (
-        (
-          !field.nullable &&
-            val === null
-        ) &&
+        !field.nullable &&
         field.required &&
         (
           val === null ||

--- a/addon/models/resource.js
+++ b/addon/models/resource.js
@@ -134,6 +134,10 @@ var Resource = Actionable.extend(TypeMixin, {
       }
 
       if (
+        (
+          !field.nullable &&
+            val === null
+        ) &&
         field.required &&
         (
           val === null ||

--- a/addon/utils/validate.js
+++ b/addon/utils/validate.js
@@ -35,10 +35,7 @@ export function validateLength(val, field, displayKey, intl, errors=[]) {
   }
 
   if (
-    (
-      !field.nullable &&
-        val === null
-    ) &&
+    !field.nullable &&
     field.required &&
     ( val === null ||
       (typeof val === 'string' && len === 0) ||

--- a/addon/utils/validate.js
+++ b/addon/utils/validate.js
@@ -35,10 +35,14 @@ export function validateLength(val, field, displayKey, intl, errors=[]) {
   }
 
   if (
+    (
+      !field.nullable &&
+        val === null
+    ) &&
     field.required &&
     ( val === null ||
       (typeof val === 'string' && len === 0) ||
-      (isArray(val) && len === 0) 
+      (isArray(val) && len === 0)
     )
   ) {
     errors.push(intl.t('validation.required', {key: displayKey}));
@@ -151,7 +155,7 @@ export function validateHostname(val, displayKey, intl, opts, errors=[]) {
   let label;
   for ( let i = 0 ; i < labels.length ; i++ ) {
     label = labels[i];
-    
+
     // Already checked if Hostname starts with a dot
     if ( i === 0 && label === "" ){
       continue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/ember-api-store",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
Required is attached to the presence of a field not the contents of the value. `nullable` fields can  be required and if they are present and null we shouldn't mark this as a validation issue. 